### PR TITLE
Reset prefix_string for each line to avoid reusing garbage between them.

### DIFF
--- a/transform_perfdata.awk
+++ b/transform_perfdata.awk
@@ -2,6 +2,9 @@ BEGIN {
     FS="\t"
 }
 
+# emptying the prefix for each line
+prefix_string=""
+
 $8 ~ /[0-9]/ {
     #Replace ponctuation marks
     gsub(/ /,"_",$3);


### PR DESCRIPTION
Hi, 

This PR fixes a bug I got with check_disk when you have a lot of partitions : the perfdata field gets truncated, and without this patch we carry the garbage from one line to another

```
[SERVICEPERFDATA]       1396386263      host1   Disk space      0.080   0.274   DISK OK - free space: /dev 10 MB (100% inode=99%): /run 3213 MB (99% inode=99%): / 17418 MB (92% inode=95%): /run/lock 5 MB (100% inode=99%): /run/shm 6629 MB (99% inode=99%): /var/lib/vz 1120570 MB (96% inode=99%): /data 1334287 MB (92% inode=99%): /etc/pve 29 MB (99% inode=99%): /var/lib/vz/root/101 38479 MB (93% inode=99%): /var/lib/vz/root/101/run 819 MB (99% inode=99%): /var/lib/vz/root/101/run/lock 5 MB (100% inode=99%): /var/lib/vz/root/101/run/shm 1740 MB (100% inode=99%): /var/lib/vz/root/102 38298 MB (93% inode=99%): /var/lib/vz/root/102/run 819 MB (99% inode=99%): /var/lib/vz/root/102/run/lock 5 MB (100% inode=99%): /var/lib/vz/root/102/run/shm 1740 MB (100% inode=99%):       /dev=0MB;8;9;0;10 /run=0MB;2731;3052;0;3213 /=1422MB;16864;18848;0;19841 /run/lock=0MB;4;4;0;5 /run/shm=3MB;5637;6300;0;6632 /var/lib/vz=37108MB;1036251;1158163;0;1219119 /data=100811MB;1285114;1436304;0;1511899 /etc/pve=0MB;25;28;0;30 /var/lib/vz/root/101=2480MB;34816;38912;0;40960 /var/lib/vz/root/101/run=0MB;696;778;0;819 /var/
[SERVICEPERFDATA]       1396386265      host2   app1 vmstat threads     0.089   0.271   Status:OK - VM Statistics, Threads: 108 vmthread_count=108;
```

This gets sent to graphite : 

```
monitoring.nagios.host1.Disk_space./dev 0 1396386263
monitoring.nagios.host1.Disk_space./run 0 1396386263
monitoring.nagios.host1.Disk_space./ 1422 1396386263
monitoring.nagios.host1.Disk_space./run/lock 0 1396386263
monitoring.nagios.host1.Disk_space./run/shm 3 1396386263
monitoring.nagios.host1.Disk_space./var/lib/vz 37108 1396386263
monitoring.nagios.host1.Disk_space./data 100811 1396386263
monitoring.nagios.host1.Disk_space./etc/pve 0 1396386263
monitoring.nagios.host1.Disk_space./var/lib/vz/root/101 2480 1396386263
monitoring.nagios.host1.Disk_space./var/lib/vz/root/101/run 0 1396386263
monitoring.nagios.host2.app1_vmstat_threads./var/_vmthread_count 108 1396386265
```

Look carefully at the last line, the "/var/_vmthread_count" instead of "vmthread_count"
